### PR TITLE
Remove datacolumn usage

### DIFF
--- a/TapResult.Tests/ColumnTests.cs
+++ b/TapResult.Tests/ColumnTests.cs
@@ -17,6 +17,7 @@ public class ColumnParent : IColumnParent
     
     public EncodingType EncodingType { get; } = EncodingType.Table;
     public LogicalType LogicalType { get; } = LogicalType.UInt8;
+    public int LogicalLength { get; } = 0;
 
     public IColumnReader OpenReader()
     {

--- a/TapResult.Tests/Encodings/BitPackingTests.cs
+++ b/TapResult.Tests/Encodings/BitPackingTests.cs
@@ -31,7 +31,7 @@ internal sealed class BitPackingTests
     {
         Span<int> bitCounts = stackalloc int[sizeof(ulong) * 8];
         DataColumn column = Assert.InstanceOf<DataColumn>(ColumnBuilder.Create<byte>(Enumerable.Range(128, 21).Select(i => (byte)i).ToArray().AsSpan()));
-        BitPacking.GetBitCounts<byte>(column,
+        BitPacking.GetBitCounts<byte>(column.OpenReader<byte>(),
             bitCounts);
         Assert.That(bitCounts.Slice(0, 8).ToArray(), Is.EqualTo(new int[8] {21, 0, 0, 5, 8, 9, 10, 10 }));
         Assert.That(bitCounts.Slice(8).ToArray().All(i => i == 0), Is.True);
@@ -41,10 +41,8 @@ internal sealed class BitPackingTests
     public void GetMetadataTest()
     {
         DataColumn column = Assert.InstanceOf<DataColumn>(ColumnBuilder.Create<byte>(Enumerable.Range(128, 21).Select(i => (byte)i).ToArray().AsSpan()));
-        BitPackingColumn metadata = BitPacking.GetMetadata<byte>(column);
-        Assert.That(metadata.LogicalLength, Is.EqualTo(21));
-        Assert.That(metadata.LogicalType, Is.EqualTo(LogicalType.UInt8));
-        Assert.That(metadata.Prefix, Is.EqualTo(0b100));
-        Assert.That(metadata.PrefixLength, Is.EqualTo(3));
+        BitPacking.GetMetadata<byte>(column.OpenReader<byte>(), out byte prefixLength, out ulong prefix);
+        Assert.That(prefix, Is.EqualTo(0b100));
+        Assert.That(prefixLength, Is.EqualTo(3));
     }
 }

--- a/TapResult.Tests/Encodings/EncodingTests.cs
+++ b/TapResult.Tests/Encodings/EncodingTests.cs
@@ -21,7 +21,8 @@ internal sealed class EncodingTests
             SamplePercentage = samplePercentage,
         };
         int[] data = Enumerable.Range(0, dataSize).ToArray();
-        DataColumn sample = encoder.CreateSample(Assert.InstanceOf<DataColumn>(ColumnBuilder.Create<int>(data)));
+        IColumn column = ColumnBuilder.Create<int>(data);
+        IColumn sample = encoder.CreateSample<int>(column.OpenReader<int>()) ?? column;
 
         int sampleLength = (int)(dataSize * samplePercentage / sampleCount);
         int totalSampleLength = sampleLength * sampleCount;

--- a/TapResult.Tests/Encodings/RunLengthTests.cs
+++ b/TapResult.Tests/Encodings/RunLengthTests.cs
@@ -21,7 +21,7 @@ public class RunLengthTests
         RunLengthColumn column = Assert.InstanceOf<RunLengthColumn>(encoding.Encode(dataColumn));
         RunLengthReader<int> reader = Assert.InstanceOf<RunLengthReader<int>>(column.OpenReader());
         
-        Assert.That(reader.Length, Is.EqualTo(column.Length));
+        Assert.That(reader.Length, Is.EqualTo(column.LogicalLength));
         Assert.That(reader.Read(length).ToArray(), Is.EqualTo(data));
     }
     
@@ -40,7 +40,7 @@ public class RunLengthTests
         
         Assert.That(column.RepeatColumn.OpenReader<int>().Read(), Is.EqualTo(repeats));
         Assert.That(column.ByteColumn.OpenReader<int>().Read(), Is.EqualTo(value));
-        Assert.That(reader.Length, Is.EqualTo(column.Length));
+        Assert.That(reader.Length, Is.EqualTo(column.LogicalLength));
         Assert.That(reader.Read(repeats).ToArray(), Is.EqualTo(data));
     }
     
@@ -55,7 +55,7 @@ public class RunLengthTests
         
         Assert.That(column.RepeatColumn.OpenReader<int>().Read(4), Is.EqualTo(new[] {7, 5, 5, 6}));
         Assert.That(column.ByteColumn.OpenReader<int>().Read(4), Is.EqualTo(new[] {1, 5, 1, 3}));
-        Assert.That(reader.Length, Is.EqualTo(column.Length));
+        Assert.That(reader.Length, Is.EqualTo(column.LogicalLength));
         Assert.That(reader.Read(data.Length).ToArray(), Is.EqualTo(data));
     }
     
@@ -70,7 +70,7 @@ public class RunLengthTests
         
         Assert.That(column.RepeatColumn.OpenReader<int>().Read(5), Is.EqualTo(new[] {7, 5, 2, 3, 6}));
         Assert.That(column.ByteColumn.OpenReader<float>().Read(5), Is.EqualTo(new[] {1.1f, 5.5f, 1.2f, 1.3f, 3.4f}));
-        Assert.That(reader.Length, Is.EqualTo(column.Length));
+        Assert.That(reader.Length, Is.EqualTo(column.LogicalLength));
         Assert.That(reader.Read(data.Length).ToArray(), Is.EqualTo(data));
     }
 }

--- a/TapResult.Tests/ReaderTests.cs
+++ b/TapResult.Tests/ReaderTests.cs
@@ -12,6 +12,8 @@ internal sealed class MyColumn : IColumnParent
 
     public required EncodingType EncodingType { get; set; } = EncodingType.Binary;
     public required LogicalType LogicalType { get; set; } = LogicalType.UInt8;
+    public int LogicalLength { get; } = 0;
+
     public IEnumerable<DataColumn> GetDataColumns()
     {
         yield break;

--- a/TapResult.Tests/TableTests.cs
+++ b/TapResult.Tests/TableTests.cs
@@ -82,7 +82,8 @@ public class TableTests
         DataColumn parentIdColumn = metadataColumns[1];
         DataColumn encodingIdColumn = metadataColumns[2];
         DataColumn logicalTypeColumn = metadataColumns[3];
-        DataColumn blobColumn = metadataColumns[4];
+        DataColumn lengthColumn = metadataColumns[4];
+        DataColumn blobColumn = metadataColumns[5];
         
         /* Table should look the following:
          * | Id | ParentId | Encoding | LogicalType | Blob
@@ -95,13 +96,13 @@ public class TableTests
         Assert.That(parentIdColumn.OpenReader<int>().Read(4), Is.EqualTo(new [] { 0, 0, 0, -1 }));
         Assert.That(encodingIdColumn.OpenReader<byte>().Read(4), Is.EqualTo( new byte[] { (byte)EncodingType.Binary, (byte)EncodingType.Binary, (byte)EncodingType.Binary, (byte)EncodingType.Table }));
         Assert.That(logicalTypeColumn.OpenReader<byte>().Read(4), Is.EqualTo(new byte[] { (byte)LogicalType.SInt32, (byte)LogicalType.SInt32, (byte)LogicalType.SInt32, (byte)LogicalType.UInt8 }));
-
+        Assert.That(lengthColumn.OpenReader<int>().Read(4), Is.EqualTo(new []{length, length, length, length}));
+        
         var blobReader = blobColumn.OpenGenericReader();
         for (int i = 0; i < 3; i++)
         {
-            Assert.That(blobReader.Read<int>(), Is.EqualTo(Unsafe.SizeOf<int>() + Unsafe.SizeOf<int>() + Unsafe.SizeOf<long>())); // Size of blob
+            Assert.That(blobReader.Read<int>(), Is.EqualTo(Unsafe.SizeOf<int>() + Unsafe.SizeOf<long>())); // Size of blob
             Assert.That(blobReader.Read<int>(), Is.EqualTo(length * Unsafe.SizeOf<int>())); // PhysicalSize
-            Assert.That(blobReader.Read<int>(), Is.EqualTo(length)); // LogicalLength
             Assert.That(blobReader.Read<long>(), Is.EqualTo(0)); // Offset, although the Column is not written out
         }
         Assert.That(blobReader.Read<int>(), Is.EqualTo(42));
@@ -214,15 +215,24 @@ public class TableTests
         Assert.That(reader.ReadBytes(4), Is.EqualTo( new [] { (byte)LogicalType.SInt32, (byte)LogicalType.SInt32, (byte)LogicalType.SInt32, (byte)LogicalType.UInt8 }));
         expectedPosition += 8;
         Assert.That(reader.BaseStream.Position, Is.EqualTo(expectedPosition));
+        
+        Assert.Multiple(() =>
+        {
+            Assert.That(reader.ReadInt32(), Is.EqualTo(length));
+            Assert.That(reader.ReadInt32(), Is.EqualTo(length));
+            Assert.That(reader.ReadInt32(), Is.EqualTo(length));
+            Assert.That(reader.ReadInt32(), Is.EqualTo(length));
+        });
+        expectedPosition += 16;
+        Assert.That(reader.BaseStream.Position, Is.EqualTo(expectedPosition));
 
         for (int i = 0; i < 3; i++)
         {
-            Assert.That(reader.ReadInt32(), Is.EqualTo(Unsafe.SizeOf<int>() + Unsafe.SizeOf<int>() + Unsafe.SizeOf<long>())); // Size of blob
+            Assert.That(reader.ReadInt32(), Is.EqualTo(Unsafe.SizeOf<int>() + Unsafe.SizeOf<long>())); // Size of blob
             Assert.That(reader.ReadInt32(), Is.EqualTo(length * Unsafe.SizeOf<int>())); // PhysicalSize
-            Assert.That(reader.ReadInt32(), Is.EqualTo(length)); // LogicalLength
             Assert.That(reader.ReadInt64(), Is.Not.EqualTo(0)); // Offset, although the Column is not written out
         }
-        expectedPosition += (4 + 4 + 4 + 8) * 3;
+        expectedPosition += (4 + 4 + 8) * 3;
         Assert.That(reader.BaseStream.Position, Is.EqualTo(expectedPosition));
         
         

--- a/TapResult.Tests/TableTests.cs
+++ b/TapResult.Tests/TableTests.cs
@@ -118,11 +118,11 @@ public class TableTests
             new BitPackingColumn(
                 new BitPackingColumn(
                     new BitPackingColumn(
-                        DataColumn.Empty, 0, 0
+                        DataColumn.Empty, 0, 0, 0
                         ), 0, 0, 0
                     ), 0, 0, 0
                 ), 
-            new BitPackingColumn(DataColumn.Empty, 0, 0), 
+            new BitPackingColumn(DataColumn.Empty, 0, 0, 0), 
             LogicalType.Blob
         );
         

--- a/TapResult/BlobBuilder.cs
+++ b/TapResult/BlobBuilder.cs
@@ -27,11 +27,11 @@ public interface IBlobBuilder
 /// </summary>
 public sealed class BlobBuilder : IBlobBuilder, IDisposable
 {
-    private readonly IRawWriter _builder;
+    private readonly IRawWriter _writer;
 
-    internal BlobBuilder(IRawWriter builder)
+    internal BlobBuilder(IRawWriter writer)
     {
-        _builder = builder;
+        _writer = writer;
     }
     
     internal int StartIndex { get; init; }
@@ -47,23 +47,23 @@ public sealed class BlobBuilder : IBlobBuilder, IDisposable
                 WriteBlob(blob);
                 break;
             default:
-                _builder.WriteRaw(value);
+                _writer.WriteRaw(value);
                 break;
         }
     }
 
     private void WriteBlob(ReadOnlySpan<byte> bytes)
     {
-        _builder.WriteRaw(bytes.Length);
-        _builder.WriteRaw(bytes);
+        _writer.WriteRaw(bytes.Length);
+        _writer.WriteRaw(bytes);
     }
     public void WriteRaw(ReadOnlySpan<byte> bytes)
     {
-        _builder.WriteRaw(bytes);
+        _writer.WriteRaw(bytes);
     }
 
     public void Dispose()
     {
-        _builder.CloseBlob();
+        _writer.CloseBlob();
     }
 }

--- a/TapResult/BlobBuilder.cs
+++ b/TapResult/BlobBuilder.cs
@@ -27,9 +27,9 @@ public interface IBlobBuilder
 /// </summary>
 public sealed class BlobBuilder : IBlobBuilder, IDisposable
 {
-    private readonly ColumnBuilder _builder;
+    private readonly IRawWriter _builder;
 
-    internal BlobBuilder(ColumnBuilder builder)
+    internal BlobBuilder(IRawWriter builder)
     {
         _builder = builder;
     }
@@ -55,11 +55,11 @@ public sealed class BlobBuilder : IBlobBuilder, IDisposable
     private void WriteBlob(ReadOnlySpan<byte> bytes)
     {
         _builder.WriteRaw(bytes.Length);
-        _builder.WriteRaw(bytes, 0);
+        _builder.WriteRaw(bytes);
     }
     public void WriteRaw(ReadOnlySpan<byte> bytes)
     {
-        _builder.WriteRaw(bytes, 0);
+        _builder.WriteRaw(bytes);
     }
 
     public void Dispose()

--- a/TapResult/ColumnBuilder.cs
+++ b/TapResult/ColumnBuilder.cs
@@ -53,6 +53,11 @@ public sealed partial class ColumnBuilder : IRawWriter
     /// </summary>
     public int PhysicalSize => _byteIndex;
 
+    /// <summary>
+    /// The current logical length of this <see cref="ColumnBuilder"/>.
+    /// </summary>
+    public int LogicalLength => _logicalLength;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     private Span<byte> Slice(int size)
     {

--- a/TapResult/ColumnBuilder.cs
+++ b/TapResult/ColumnBuilder.cs
@@ -8,10 +8,18 @@ using TapResult.Columns;
 
 namespace TapResult;
 
+internal interface IRawWriter
+{
+    public void WriteRaw<T>(ReadOnlySpan<T> bytes, int count = 0) where T : unmanaged;
+    public void WriteRaw<T>(T bytes);
+    public void CloseBlob();
+}
+
+
 /// <summary>
 /// Helper type for making <see cref="DataColumn"/>.
 /// </summary>
-public sealed partial class ColumnBuilder
+public sealed partial class ColumnBuilder : IRawWriter
 {
     private readonly LogicalType _type;
     private BlobBuilder? _blobBuilder = null;
@@ -126,7 +134,7 @@ public sealed partial class ColumnBuilder
     private void WriteBlob(ReadOnlySpan<byte> blob)
     {
         WriteRaw(blob.Length);
-        WriteRaw(blob, 0);
+        WriteRaw(blob);
     }
     
     /// <summary>
@@ -136,23 +144,12 @@ public sealed partial class ColumnBuilder
     {
         WriteRaw(Encoding.UTF8.GetBytes(str));
     }
-    
-    /// <summary>
-    /// Writes multiple strings to the DataColumn.
-    /// </summary>
-    private void WriteStrings(IEnumerable<string> strs)
-    {
-        foreach (string str in strs)
-        {
-            WriteValue(str);
-        }
-    }
 
     /// <summary>
     /// Writes multiple values to the DataColumn, this only increases LogicalLength by the provided value.
-    /// Generally use <see cref="WriteValues{T}"/> unless you have a good reason to override the added length.
+    /// Generally use <see cref="WriteValue{T}"/> unless you have a good reason to override the added length.
     /// </summary>
-    public void WriteRaw<T>(ReadOnlySpan<T> values, int logicalLength)
+    public void WriteRaw<T>(ReadOnlySpan<T> values, int logicalLength = 0)
         where T : unmanaged
     {
         _logicalLength += logicalLength;
@@ -243,7 +240,7 @@ public sealed partial class ColumnBuilder
     /// <summary>
     /// Closes the currently open <see cref="BlobBuilder"/>, if one exists, on this <see cref="ColumnBuilder"/>.
     /// </summary>
-    internal void CloseBlob()
+    void IRawWriter.CloseBlob()
     {
         if (_blobBuilder is null)
         {

--- a/TapResult/Columns/BitPackingColumn.cs
+++ b/TapResult/Columns/BitPackingColumn.cs
@@ -40,7 +40,6 @@ internal sealed class BitPackingColumn : IColumnParent
     {
         blobBuilder.WriteValue(PrefixLength);
         blobBuilder.WriteValue(Prefix);
-        blobBuilder.WriteValue(LogicalLength);
     }
 
     public IColumnReader OpenReader()

--- a/TapResult/Columns/BitPackingColumn.cs
+++ b/TapResult/Columns/BitPackingColumn.cs
@@ -12,7 +12,7 @@ internal sealed class BitPackingColumn : IColumnParent
     public int LogicalLength { get; }
     public LogicalType LogicalType { get; }
     public EncodingType EncodingType => EncodingType.BitPacking;
-    public IColumn Column { get; set; }
+    public IColumn Column { get; private set; }
 
     public BitPackingColumn(IColumn column, byte prefixLength, ulong prefix, int logicalLength)
     {
@@ -22,9 +22,6 @@ internal sealed class BitPackingColumn : IColumnParent
         LogicalLength = logicalLength;
         LogicalType = column.LogicalType;
     }
-    
-    public BitPackingColumn(DataColumn column, byte prefixLength, ulong prefix) : this(column, prefixLength, prefix, column.LogicalLength)
-    { }
 
     public IEnumerable<IColumn> GetChildColumns()
     {

--- a/TapResult/Columns/DataColumn.cs
+++ b/TapResult/Columns/DataColumn.cs
@@ -86,7 +86,6 @@ public sealed class DataColumn : IColumn
     void IColumn.WriteMetadata(IBlobBuilder blobBuilder)
     {
         blobBuilder.WriteValue(PhysicalSize);
-        blobBuilder.WriteValue(LogicalLength);
         blobBuilder.WriteValue(_offset);
     }
 

--- a/TapResult/Columns/DataColumn.cs
+++ b/TapResult/Columns/DataColumn.cs
@@ -58,17 +58,17 @@ public sealed class DataColumn : IColumn
     {
         return LogicalType switch
         {
-            LogicalType.SInt8 => new PrimitiveReader<sbyte>(Data),
-            LogicalType.SInt16 => new PrimitiveReader<short>(Data),
-            LogicalType.SInt32 => new PrimitiveReader<int>(Data),
-            LogicalType.SInt64 => new PrimitiveReader<long>(Data),
-            LogicalType.UInt8 => new PrimitiveReader<byte>(Data),
-            LogicalType.UInt16 => new PrimitiveReader<ushort>(Data),
-            LogicalType.UInt32 => new PrimitiveReader<uint>(Data),
-            LogicalType.UInt64 => new PrimitiveReader<ulong>(Data),
-            LogicalType.Float16 => new PrimitiveReader<Half>(Data),
-            LogicalType.Float32 => new PrimitiveReader<float>(Data),
-            LogicalType.Float64 => new PrimitiveReader<double>(Data),
+            LogicalType.SInt8 => new PrimitiveReader<sbyte>(Data, LogicalType),
+            LogicalType.SInt16 => new PrimitiveReader<short>(Data, LogicalType),
+            LogicalType.SInt32 => new PrimitiveReader<int>(Data, LogicalType),
+            LogicalType.SInt64 => new PrimitiveReader<long>(Data, LogicalType),
+            LogicalType.UInt8 => new PrimitiveReader<byte>(Data, LogicalType),
+            LogicalType.UInt16 => new PrimitiveReader<ushort>(Data, LogicalType),
+            LogicalType.UInt32 => new PrimitiveReader<uint>(Data, LogicalType),
+            LogicalType.UInt64 => new PrimitiveReader<ulong>(Data, LogicalType),
+            LogicalType.Float16 => new PrimitiveReader<Half>(Data, LogicalType),
+            LogicalType.Float32 => new PrimitiveReader<float>(Data, LogicalType),
+            LogicalType.Float64 => new PrimitiveReader<double>(Data, LogicalType),
             LogicalType.Blob => new VarLengthReader(Data, LogicalLength, LogicalType),
             LogicalType.String => new VarLengthReader(Data, LogicalLength, LogicalType),
             _ => throw new ArgumentOutOfRangeException(nameof(LogicalType), typeof(LogicalType), null)

--- a/TapResult/Columns/IColumn.cs
+++ b/TapResult/Columns/IColumn.cs
@@ -16,6 +16,7 @@ public interface IColumn
     /// The logical type of this column.
     /// </summary>
     public LogicalType LogicalType { get; }
+    public int LogicalLength { get; }
     internal void WriteMetadata(IBlobBuilder blobBuilder);
 
     /// <summary>

--- a/TapResult/Columns/IColumn.cs
+++ b/TapResult/Columns/IColumn.cs
@@ -1,4 +1,5 @@
-﻿using TapResult.Encodings;
+﻿using System.Diagnostics.CodeAnalysis;
+using TapResult.Encodings;
 using TapResult.Readers;
 
 namespace TapResult.Columns;

--- a/TapResult/Columns/NullColumn.cs
+++ b/TapResult/Columns/NullColumn.cs
@@ -24,36 +24,28 @@ internal sealed class NullColumn : IColumnParent
         blobBuilder.WriteValue(LogicalLength);
     }
 
-    public IColumnReader OpenReader() => LogicalType switch
+    public IColumnReader OpenReader()
     {
-        LogicalType.SInt8 => new NullReaderValType<sbyte>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.SInt16 => new NullReaderValType<short>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.SInt32 => new NullReaderValType<int>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.SInt64 => new NullReaderValType<long>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.UInt8 => new NullReaderValType<byte>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.UInt16 => new NullReaderValType<ushort>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.UInt32 => new NullReaderValType<uint>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.UInt64 => new NullReaderValType<ulong>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.Float16 => new NullReaderValType<Half>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.Float32 => new NullReaderValType<float>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.Float64 => new NullReaderValType<double>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.Blob => new NullReaderRefType<byte[]>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        LogicalType.String => new NullReaderRefType<string>(_nullColumn.OpenReader<byte>(), _valueColumn.OpenReader(),
-            LogicalLength),
-        _ => throw new ArgumentOutOfRangeException()
-    };
+        IColumnReader<byte> nullReader = _nullColumn.OpenReader<byte>();
+        IColumnReader valueReader = _valueColumn.OpenReader();
+        return LogicalType switch
+        {
+            LogicalType.SInt8 => new NullReaderValType<sbyte>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.SInt16 => new NullReaderValType<short>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.SInt32 => new NullReaderValType<int>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.SInt64 => new NullReaderValType<long>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.UInt8 => new NullReaderValType<byte>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.UInt16 => new NullReaderValType<ushort>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.UInt32 => new NullReaderValType<uint>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.UInt64 => new NullReaderValType<ulong>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.Float16 => new NullReaderValType<Half>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.Float32 => new NullReaderValType<float>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.Float64 => new NullReaderValType<double>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.Blob => new NullReaderRefType<byte[]>(nullReader, valueReader, LogicalLength, LogicalType),
+            LogicalType.String => new NullReaderRefType<string>(nullReader, valueReader, LogicalLength, LogicalType),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
 
     public IEnumerable<IColumn> GetChildColumns()
     {

--- a/TapResult/Columns/RunLengthColumn.cs
+++ b/TapResult/Columns/RunLengthColumn.cs
@@ -6,12 +6,12 @@ namespace TapResult.Columns;
 
 internal sealed class RunLengthColumn : IColumnParent
 {
-    public RunLengthColumn(LogicalType logicalType, IColumn byteColumn, IColumn repeatColumn, int length)
+    public RunLengthColumn(LogicalType logicalType, IColumn byteColumn, IColumn repeatColumn, int logicalLength)
     {
         LogicalType = logicalType;
         ByteColumn = byteColumn;
         RepeatColumn = repeatColumn;
-        Length = length;
+        LogicalLength = logicalLength;
     }
 
     public EncodingType EncodingType { get; } = EncodingType.RunLength;
@@ -19,16 +19,15 @@ internal sealed class RunLengthColumn : IColumnParent
 
     public IColumn ByteColumn { get; set; }
     public IColumn RepeatColumn { get; set; }
-    public int Length { get; set; }
+    public int LogicalLength { get; set; }
 
     public void WriteMetadata(IBlobBuilder blobBuilder)
     {
-        blobBuilder.WriteValue(Length);
     }
 
     public IColumnReader OpenReader()
     {
-        return RunLengthEncoding.CreateReader(LogicalType, ByteColumn.OpenReader(), RepeatColumn.OpenReader<int>(), Length);
+        return RunLengthEncoding.CreateReader(LogicalType, ByteColumn.OpenReader(), RepeatColumn.OpenReader<int>(), LogicalLength);
     }
 
     public IEnumerable<IColumn> GetChildColumns()

--- a/TapResult/Columns/SplitColumn.cs
+++ b/TapResult/Columns/SplitColumn.cs
@@ -8,6 +8,7 @@ internal sealed class SplitColumn : IColumnParent
     public IColumn LengthColumn { get; set; }
     public IColumn ByteColumn { get; set; }
     public LogicalType LogicalType { get; }
+    public int LogicalLength => LengthColumn.LogicalLength;
     public EncodingType EncodingType => EncodingType.Split;
 
     public SplitColumn(IColumn lengthColumn, IColumn byteColumn, LogicalType logicalType)

--- a/TapResult/Encoder.cs
+++ b/TapResult/Encoder.cs
@@ -14,7 +14,6 @@ public sealed class Encoder
     /// </summary>
     public static IEnumerable<IEncoding> GetDefaultEncodings()
     {
-        yield return new SplitEncoding();
         yield return new BitPacking();
         yield return new RunLengthEncoding();
     }
@@ -75,14 +74,48 @@ public sealed class Encoder
     /// <remarks> Only relevant on encode. </remarks>
     public int SampleMaxLength { get; init; } = 1024;
     
-    internal IColumn Encode(DataColumn column)
+    internal IColumn Encode(IColumn column)
     {
-        DataColumn sample = CreateSample(column);
+        return column.LogicalType switch
+        {
+            LogicalType.SInt8 => Encode<sbyte>(column),
+            LogicalType.SInt16 => Encode<short>(column),
+            LogicalType.SInt32 => Encode<int>(column),
+            LogicalType.SInt64 => Encode<long>(column),
+            LogicalType.UInt8 => Encode<byte>(column),
+            LogicalType.UInt16 => Encode<ushort>(column),
+            LogicalType.UInt32 => Encode<uint>(column),
+            LogicalType.UInt64 => Encode<ulong>(column),
+            LogicalType.Float16 => Encode<Half>(column),
+            LogicalType.Float32 => Encode<float>(column),
+            LogicalType.Float64 => Encode<double>(column),
+            LogicalType.Blob => Encode<byte[]>(column),
+            LogicalType.String => Encode<string>(column),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+
+    private IColumn Encode<T>(IColumn column)
+    {
+        IColumn? sample;
+        if (typeof(T) == typeof(string))
+        {
+            IColumnReader<string> columnReader = column.OpenReader<string>();
+            sample = columnReader.TryConvertReader<byte[]>(out IColumnReader<byte[]>? reader) ?
+                CreateSample<byte[]>(reader) :
+                CreateSample<string>(columnReader);
+        }
+        else
+        {
+            sample = CreateSample<T>(column.OpenReader<T>());
+        }
+
+        sample ??= column;
         IColumn metadataSample = PickEncoding(sample, CascadingEncodings);
         return Encode(column, metadataSample);
     }
 
-    private IColumn Encode(DataColumn inData, IColumn metadataSample)
+    private IColumn Encode(IColumn inData, IColumn metadataSample)
     {
         if (metadataSample is DataColumn)
         {
@@ -105,13 +138,13 @@ public sealed class Encoder
         return columns;
     }
 
-    private IColumn PickEncoding(DataColumn sample, int cascades)
+    private IColumn PickEncoding(IColumn sample, int cascades)
     {
         if (cascades == 0)
         {
             return sample;
         }
-        int minSize = sample.PhysicalSize / 4 * 3;
+        int minSize = CalculateTotalLength(sample) / 4 * 3;
         IColumn bestEncoding = sample;
         if (!_encodingsByType.Contains(sample.LogicalType))
         {
@@ -153,29 +186,28 @@ public sealed class Encoder
         return 0;
     }
 
-    internal DataColumn CreateSample(in DataColumn data)
+    internal IColumn? CreateSample<T>(IColumnReader<T> reader)
     {
-        int length = data.LogicalLength;
+        int length = reader.Length;
         if (length * SamplePercentage < SampleCount)
         {
-            return data;
+            return null;
         }
         
         // Need to calculate sample length first, to round correctly.
         var sampleLength = (int)(length * SamplePercentage) / SampleCount;
         sampleLength = Math.Min(sampleLength, SampleMaxLength);
         var totalSampleLength = sampleLength * SampleCount;
-        int size = data.LogicalType.TryGetSize(out int s) ? s : 1;
-        ColumnBuilder builder = new ColumnBuilder(data.LogicalType, totalSampleLength * size);
-        GenericReader reader = data.OpenGenericReader();
+        int size = reader.Type.TryGetSize(out int s) ? s : 1;
+        ColumnBuilder builder = new ColumnBuilder(reader.Type, totalSampleLength * size);
         
         int sectionLength = length / SampleCount;
         for (int i = 0; i < SampleCount; i++)
         {
             int index = Random.Shared.Next(0, sectionLength - sampleLength);
-            reader.AdvanceUnits(data.LogicalType, index);
-            builder.WriteRaw(reader.ReadUnits(data.LogicalType, sampleLength), sampleLength);
-            reader.AdvanceUnits(data.LogicalType, sectionLength - index - sampleLength);
+            reader.Advance(index);
+            builder.WriteValues(reader.Read(sampleLength));
+            reader.Advance(sectionLength - index - sampleLength);
         }
 
         return builder.BuildDataColumn();

--- a/TapResult/Encoder.cs
+++ b/TapResult/Encoder.cs
@@ -48,10 +48,10 @@ public sealed class Encoder
             .ToLookup(t => t.t, t => t.e);
     }
 
-    internal IColumnReader Decode(EncodingType encodingType, LogicalType type, ref GenericReader blobReader, IEnumerable<IColumnReader> childColumns)
+    internal IColumnReader Decode(EncodingType encodingType, LogicalType type, int length, ref GenericReader blobReader, IEnumerable<IColumnReader> childColumns)
     {
         IEncoding encoding = _encodingsById[encodingType];
-        return encoding.CreateDecoder(type, blobReader, childColumns);
+        return encoding.CreateDecoder(type, length, blobReader, childColumns);
     }
     
     /// <summary>

--- a/TapResult/EncodingInfo.cs
+++ b/TapResult/EncodingInfo.cs
@@ -25,6 +25,10 @@ public sealed class EncodingInfo
     /// </summary>
     public LogicalType Type { get; }
     /// <summary>
+    /// The logical length of this encoded column.
+    /// </summary>
+    public int Length { get; }
+    /// <summary>
     /// A blob containing metadata for this encoding.
     /// </summary>
     public ReadOnlyMemory<byte> Blob { get; }
@@ -33,12 +37,13 @@ public sealed class EncodingInfo
     /// </summary>
     public EncodingInfo? ParentEncoding { get; private set; } = null;
 
-    internal EncodingInfo(int id, int parentId, EncodingType encoding, LogicalType type, ReadOnlyMemory<byte> blob)
+    internal EncodingInfo(int id, int parentId, EncodingType encoding, LogicalType type, int length, ReadOnlyMemory<byte> blob)
     {
         Id = id;
         ParentId = parentId;
         Encoding = encoding;
         Type = type;
+        Length = length;
         Blob = blob;
     }
 

--- a/TapResult/Encodings/BitPacking.cs
+++ b/TapResult/Encodings/BitPacking.cs
@@ -13,23 +13,20 @@ public sealed class BitPacking : IEncoding
 {
     public EncodingType Type { get; } = EncodingType.BitPacking;
     
-    public IColumn Encode(DataColumn dataColumn)
+    public IColumn Encode<T>(IColumnReader<T> dataColumn) where T : notnull
     {
-        if (!dataColumn.LogicalType.TryGetSize(out int size))
+        return dataColumn switch
         {
-            throw new Exception("Type must be a primitive.");
-        }
-        
-        IColumn column = size switch
-        {
-            1 => Encode<byte>(dataColumn),
-            2 => Encode<ushort>(dataColumn),
-            4 => Encode<uint>(dataColumn),
-            8 => Encode<ulong>(dataColumn),
-            _ => throw new Exception("Logical type size must be either 1, 2, 4 or 8."),
+            IColumnReader<sbyte> reader => EncodeData(reader),
+            IColumnReader<short> reader => EncodeData(reader),
+            IColumnReader<int> reader => EncodeData(reader),
+            IColumnReader<long> reader => EncodeData(reader),
+            IColumnReader<byte> reader => EncodeData(reader),
+            IColumnReader<ushort> reader => EncodeData(reader),
+            IColumnReader<uint> reader => EncodeData(reader),
+            IColumnReader<ulong> reader => EncodeData(reader),
+            _ => throw new ArgumentOutOfRangeException(nameof(dataColumn)),
         };
-
-        return column;
     }
 
     public IColumnReader CreateDecoder(LogicalType type, GenericReader metadataReader, IEnumerable<IColumnReader> childReader)
@@ -43,64 +40,54 @@ public sealed class BitPacking : IEncoding
         return OpenReader(reader, logicalLength, type, prefixLength, prefix);
     }
 
-    private static IColumn Encode<T>(in DataColumn dataColumn)
+    private static IColumn EncodeData<T>(IColumnReader<T> reader)
         where T : unmanaged, IBinaryInteger<T>, IMinMaxValue<T>
     {
-        BitPackingColumn metadata = GetMetadata<T>(dataColumn);
-        EncodeData<T>(dataColumn, metadata);
-        return metadata;
-    }
-
-    private static void EncodeData<T>(in DataColumn dataColumn, BitPackingColumn metadata)
-        where T : unmanaged, INumber<T>, IBinaryInteger<T>, IMinMaxValue<T>
-    {
-        IColumnReader<T> reader = new PrimitiveReader<T>(dataColumn.Data);
+        GetMetadata<T>(reader.Clone(), out byte prefixLength, out ulong prefix);
         int size = Unsafe.SizeOf<T>() * 8;
-        int packedSize = size - metadata.PrefixLength;
-        int length = (int)double.Ceiling(dataColumn.PhysicalSize * (packedSize / (double)size)) + 1;
-        ColumnBuilder builder = new ColumnBuilder(dataColumn.LogicalType, length * Unsafe.SizeOf<T>());
-        T flag = (T.AllBitsSet << metadata.PrefixLength) >>> metadata.PrefixLength;
+        int packedSize = size - prefixLength;
+        int length = (int)double.Ceiling(reader.Length / (double)packedSize) + 1;
+        ColumnBuilder builder = new ColumnBuilder(typeof(T).ToLogicalType(), length * Unsafe.SizeOf<T>());
+        T flag = (T.AllBitsSet << prefixLength) >>> prefixLength;
         T currentValue = default;
         int shift = 0;
         while (!reader.IsAtEnd)
         {
-             T value = reader.Read() & flag;
-             if (shift + packedSize < size)
-             {
-                 currentValue = (currentValue << packedSize) | value;
-                 shift += packedSize;
-             }
-             else
-             {
-                 shift = size - shift;
-                 T value1 = value >> (packedSize - shift);
-                 currentValue = (currentValue << shift) | value1;
-                 builder.WriteValue(currentValue);
+            T value = reader.Read() & flag;
+            if (shift + packedSize < size)
+            {
+                currentValue = (currentValue << packedSize) | value;
+                shift += packedSize;
+            }
+            else
+            {
+                shift = size - shift;
+                T value1 = value >> (packedSize - shift);
+                currentValue = (currentValue << shift) | value1;
+                builder.WriteValue(currentValue);
 
-                 currentValue = value;
-                 shift = packedSize - shift;
-             }
+                currentValue = value;
+                shift = packedSize - shift;
+            }
         }
 
         currentValue <<= size - shift;
         builder.WriteValue(currentValue);
-
-        metadata.Column = builder.BuildDataColumn();
+        return new BitPackingColumn(builder.Build(), prefixLength, prefix, builder.PhysicalSize);
     }
 
-    internal static BitPackingColumn GetMetadata<T>(in DataColumn data) where T : unmanaged, IBinaryInteger<T>
+    internal static void GetMetadata<T>(IColumnReader<T> data, out byte prefixLength, out ulong prefix) where T : unmanaged, IBinaryInteger<T>
     {
         Span<int> bitCounts = stackalloc int[Unsafe.SizeOf<ulong>() * 8];
         GetBitCounts<T>(data, bitCounts);
-        int count = data.LogicalLength;
-        
-        byte prefixLength = 0;
-        ulong prefix = 0;
 
+        prefixLength = 0;
+        prefix = 0;
+        
         for (int i = 0; i < Unsafe.SizeOf<T>() * 8 - 1; i++)
         {
             int bitCount = bitCounts[i];
-            if (bitCount == count)
+            if (bitCount == data.Length)
             {
                 prefixLength += 1;
                 prefix = (prefix << 1) | 1;
@@ -115,16 +102,14 @@ public sealed class BitPacking : IEncoding
                 break;
             }
         }
-        return new BitPackingColumn(data, prefixLength, prefix);
     }
 
-    internal static void GetBitCounts<T>(in DataColumn column, Span<int> bitCounts)
+    internal static void GetBitCounts<T>(IColumnReader<T> reader, Span<int> bitCounts)
         where T : unmanaged, INumber<T>, IBinaryInteger<T>
     {
         // TODO: Optimize using SIMD and PopCount.
-        IColumnReader<T> reader = new PrimitiveReader<T>(column.Data);
         int size = Unsafe.SizeOf<T>() * 8;
-        for (int i = 0; i < column.LogicalLength; i++)
+        for (int i = 0; i < reader.Length; i++)
         {
             T value = reader.Read();
             // TODO: Skip leading zeros.

--- a/TapResult/Encodings/BitPacking.cs
+++ b/TapResult/Encodings/BitPacking.cs
@@ -29,15 +29,14 @@ public sealed class BitPacking : IEncoding
         };
     }
 
-    public IColumnReader CreateDecoder(LogicalType type, GenericReader metadataReader, IEnumerable<IColumnReader> childReader)
+    public IColumnReader CreateDecoder(LogicalType type, int length, GenericReader metadataReader, IEnumerable<IColumnReader> childReader)
     {
         IColumnReader? reader = childReader.FirstOrDefault();
         if (reader is null)
             throw new Exception("Expected a child column to a bitpack encoded column, but found none.");
         byte prefixLength = metadataReader.Read<byte>();
         ulong prefix = metadataReader.Read<ulong>();
-        int logicalLength = metadataReader.Read<int>();
-        return OpenReader(reader, logicalLength, type, prefixLength, prefix);
+        return OpenReader(reader, length, type, prefixLength, prefix);
     }
 
     private static IColumn EncodeData<T>(IColumnReader<T> reader)

--- a/TapResult/Encodings/IEncoding.cs
+++ b/TapResult/Encodings/IEncoding.cs
@@ -35,7 +35,7 @@ public interface IEncoding
     /// The decoder must be an IColumnReader,
     /// and the IColumnReader should ideally have a more specific type that depends on the type of LogicalType.
     /// </summary>
-    IColumnReader CreateDecoder(LogicalType type, GenericReader metadataReader, params IEnumerable<IColumnReader> childColumns);
+    IColumnReader CreateDecoder(LogicalType type, int length, GenericReader metadataReader, params IEnumerable<IColumnReader> childColumns);
 
     /// <summary>
     /// Gets the supported LogicalTypes of this Encoding.

--- a/TapResult/Encodings/IEncoding.cs
+++ b/TapResult/Encodings/IEncoding.cs
@@ -28,7 +28,7 @@ public interface IEncoding
     /// <summary>
     /// Encode a DataColumn using the encoding specified by <see cref="Type"/>.
     /// </summary>
-    IColumn Encode(DataColumn dataColumn);
+    IColumn Encode<T>(IColumnReader<T> reader) where T : notnull;
 
     /// <summary>
     /// Create a decoder for this type of encoding.
@@ -42,4 +42,35 @@ public interface IEncoding
     /// See <see cref="TypeHelper"/> for methods to get common groups of types.
     /// </summary>
     IEnumerable<LogicalType> GetSupportedTypes();
+}
+
+/// <summary>
+/// Extensions all <see cref="IEncoding"/> will have in common.
+/// </summary>
+public static class EncodingExtensions
+{
+    /// <summary>
+    /// Encode a column on an encoding.
+    /// Will call the underlying <see cref="IEncoding.Encode"/> method with the correct type of reader.
+    /// </summary>
+    public static IColumn Encode(this IEncoding encoding, IColumn column)
+    {
+        return column.LogicalType switch
+        {
+            LogicalType.SInt8 => encoding.Encode(column.OpenReader<sbyte>()),
+            LogicalType.SInt16 => encoding.Encode(column.OpenReader<short>()),
+            LogicalType.SInt32 => encoding.Encode(column.OpenReader<int>()),
+            LogicalType.SInt64 => encoding.Encode(column.OpenReader<long>()),
+            LogicalType.UInt8 => encoding.Encode(column.OpenReader<byte>()),
+            LogicalType.UInt16 => encoding.Encode(column.OpenReader<ushort>()),
+            LogicalType.UInt32 => encoding.Encode(column.OpenReader<uint>()),
+            LogicalType.UInt64 => encoding.Encode(column.OpenReader<ulong>()),
+            LogicalType.Float16 => encoding.Encode(column.OpenReader<Half>()),
+            LogicalType.Float32 => encoding.Encode(column.OpenReader<float>()),
+            LogicalType.Float64 => encoding.Encode(column.OpenReader<double>()),
+            LogicalType.Blob => encoding.Encode(column.OpenReader<byte[]>()),
+            LogicalType.String => encoding.Encode(column.OpenReader<string>()),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
 }

--- a/TapResult/Encodings/RunLengthEncoding.cs
+++ b/TapResult/Encodings/RunLengthEncoding.cs
@@ -12,39 +12,13 @@ public sealed class RunLengthEncoding : IEncoding
 {
     public EncodingType Type { get; } = EncodingType.RunLength;
     
-    public IColumn Encode(DataColumn dataColumn)
+    public IColumn Encode<T>(IColumnReader<T> reader) where T : notnull
     {
-        IColumn column = dataColumn.LogicalType switch
-        {
-            LogicalType.SInt8 => Encode<sbyte>(dataColumn),
-            LogicalType.SInt16 => Encode<short>(dataColumn),
-            LogicalType.SInt32 => Encode<int>(dataColumn),
-            LogicalType.SInt64 => Encode<long>(dataColumn),
-            LogicalType.UInt8 => Encode<byte>(dataColumn),
-            LogicalType.UInt16 => Encode<ushort>(dataColumn),
-            LogicalType.UInt32 => Encode<uint>(dataColumn),
-            LogicalType.UInt64 => Encode<ulong>(dataColumn),
-            LogicalType.Float16 => Encode<Half>(dataColumn),
-            LogicalType.Float32 => Encode<float>(dataColumn),
-            LogicalType.Float64 => Encode<double>(dataColumn),
-            LogicalType.Blob => Encode<byte[]>(dataColumn),
-            LogicalType.String => Encode<string>(dataColumn),
-            _ => throw new Exception("Logical type size must be either 1, 2, 4 or 8."),
-        };
-
-        return column;
-    }
-
-    public IColumn Encode<T>(DataColumn dataColumn)
-        where T : notnull
-    {
-        IColumnReader<T> reader = dataColumn.OpenReader<T>();
-        GenericReader genericReader = dataColumn.OpenGenericReader();
-        ColumnBuilder byteBuilder = new ColumnBuilder(dataColumn.LogicalType, dataColumn.PhysicalSize);
-        ColumnBuilder repeatBuilder = new ColumnBuilder(LogicalType.SInt32, dataColumn.LogicalLength * Unsafe.SizeOf<int>());
+        ColumnBuilder byteBuilder = new ColumnBuilder(typeof(T).ToLogicalType(), reader.Length * 4);
+        ColumnBuilder repeatBuilder = new ColumnBuilder(LogicalType.SInt32, reader.Length * Unsafe.SizeOf<int>());
         T previous = reader.Read();
         int repeats = 1;
-        for (int i = 1; i < dataColumn.LogicalLength; i++)
+        for (int i = 1; i < reader.Length; i++)
         {
             T current = reader.Read();
             if (current.Equals(previous))
@@ -53,16 +27,15 @@ public sealed class RunLengthEncoding : IEncoding
                 continue;
             }
 
-            byteBuilder.WriteRaw(genericReader.ReadUnits(dataColumn.LogicalType), 1);
-            genericReader.AdvanceUnits(dataColumn.LogicalType, repeats - 1);
+            byteBuilder.WriteValue(previous);
             repeatBuilder.WriteValue(repeats);
             previous = current;
             repeats = 1;
         }
-        byteBuilder.WriteRaw(genericReader.ReadUnits(dataColumn.LogicalType), 1);
+        byteBuilder.WriteValue(previous);
         repeatBuilder.WriteValue(repeats);
 
-        return new RunLengthColumn(dataColumn.LogicalType, byteBuilder.Build(), repeatBuilder.Build(), dataColumn.LogicalLength);
+        return new RunLengthColumn(typeof(T).ToLogicalType(), byteBuilder.Build(), repeatBuilder.Build(), reader.Length);
     }
 
 

--- a/TapResult/Encodings/RunLengthEncoding.cs
+++ b/TapResult/Encodings/RunLengthEncoding.cs
@@ -53,17 +53,17 @@ public sealed class RunLengthEncoding : IEncoding
     {
         return type switch
         {
-            LogicalType.SInt8 => new RunLengthReader<sbyte>(byteReader, repeatReader, length),
-            LogicalType.SInt16 => new RunLengthReader<short>(byteReader, repeatReader, length),
-            LogicalType.SInt32 => new RunLengthReader<int>(byteReader, repeatReader, length),
-            LogicalType.SInt64 => new RunLengthReader<long>(byteReader, repeatReader, length),
-            LogicalType.UInt8 => new RunLengthReader<byte>(byteReader, repeatReader, length),
-            LogicalType.UInt16 => new RunLengthReader<ushort>(byteReader, repeatReader, length),
-            LogicalType.UInt32 => new RunLengthReader<uint>(byteReader, repeatReader, length),
-            LogicalType.UInt64 => new RunLengthReader<ulong>(byteReader, repeatReader, length),
-            LogicalType.Float16 => new RunLengthReader<Half>(byteReader, repeatReader, length),
-            LogicalType.Float32 => new RunLengthReader<float>(byteReader, repeatReader, length),
-            LogicalType.Float64 => new RunLengthReader<double>(byteReader, repeatReader, length),
+            LogicalType.SInt8 => new RunLengthReader<sbyte>(byteReader, repeatReader, length, type),
+            LogicalType.SInt16 => new RunLengthReader<short>(byteReader, repeatReader, length, type),
+            LogicalType.SInt32 => new RunLengthReader<int>(byteReader, repeatReader, length, type),
+            LogicalType.SInt64 => new RunLengthReader<long>(byteReader, repeatReader, length, type),
+            LogicalType.UInt8 => new RunLengthReader<byte>(byteReader, repeatReader, length, type),
+            LogicalType.UInt16 => new RunLengthReader<ushort>(byteReader, repeatReader, length, type),
+            LogicalType.UInt32 => new RunLengthReader<uint>(byteReader, repeatReader, length, type),
+            LogicalType.UInt64 => new RunLengthReader<ulong>(byteReader, repeatReader, length, type),
+            LogicalType.Float16 => new RunLengthReader<Half>(byteReader, repeatReader, length, type),
+            LogicalType.Float32 => new RunLengthReader<float>(byteReader, repeatReader, length, type),
+            LogicalType.Float64 => new RunLengthReader<double>(byteReader, repeatReader, length, type),
 
             // Explicitly throw argument out of range exception so we can get warnings if LogicalType adds new types.
             LogicalType.Blob => throw new ArgumentOutOfRangeException(nameof(type), type, null),

--- a/TapResult/Encodings/RunLengthEncoding.cs
+++ b/TapResult/Encodings/RunLengthEncoding.cs
@@ -39,14 +39,13 @@ public sealed class RunLengthEncoding : IEncoding
     }
 
 
-    public IColumnReader CreateDecoder(LogicalType type, GenericReader metadataReader, params IEnumerable<IColumnReader> childColumns)
+    public IColumnReader CreateDecoder(LogicalType type, int length, GenericReader metadataReader, params IEnumerable<IColumnReader> childColumns)
     {
         using IEnumerator<IColumnReader> childColumnEnumerator = childColumns.GetEnumerator();
         if (!childColumnEnumerator.MoveNext() || childColumnEnumerator.Current is not { } bytes ||
             !childColumnEnumerator.MoveNext() || childColumnEnumerator.Current is not IColumnReader<int> repeats ||
             childColumnEnumerator.MoveNext())
             throw new Exception("Child columns not configured correctly for RunLength column.");
-        int length = metadataReader.Read<int>();
         return CreateReader(type, bytes, repeats, length);
     }
 

--- a/TapResult/Encodings/SplitEncoding.cs
+++ b/TapResult/Encodings/SplitEncoding.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
 using TapResult.Columns;
 using TapResult.Readers;
 
@@ -10,20 +12,30 @@ namespace TapResult.Encodings;
 public sealed class SplitEncoding : IEncoding
 {
     public EncodingType Type { get; } = EncodingType.Split;
-    public IColumn Encode(DataColumn dataColumn)
+    public IColumn Encode<T>(IColumnReader<T> reader) where T : notnull
     {
-        GenericReader columnReader = dataColumn.OpenGenericReader();
-        int length = dataColumn.LogicalLength;
-        ColumnBuilder lengthBuilder = new ColumnBuilder(LogicalType.SInt32, dataColumn.LogicalLength * Unsafe.SizeOf<int>());
-        ColumnBuilder byteBuilder = new ColumnBuilder(LogicalType.UInt8, dataColumn.PhysicalSize - lengthBuilder.PhysicalSize);
-        for (int i = 0; i < length; i++)
+        ColumnBuilder lengthBuilder = new ColumnBuilder(LogicalType.SInt32, reader.Length * Unsafe.SizeOf<int>());
+        ColumnBuilder byteBuilder = new ColumnBuilder(LogicalType.UInt8, reader.Length - lengthBuilder.PhysicalSize);
+        for (int i = 0; i < reader.Length; i++)
         {
-            ReadOnlySpan<byte> blob = columnReader.ReadUnits(dataColumn.LogicalType);
-            lengthBuilder.WriteRaw(blob.Slice(0, Unsafe.SizeOf<int>()), 1);
-            byteBuilder.WriteValues(blob.Slice(Unsafe.SizeOf<int>()));
+            byte[] values;
+            if (reader is IColumnReader<byte[]> bReader)
+            {
+                values = bReader.Read();
+            }
+            else if (reader is IColumnReader<string> strReader)
+            {
+                values = Encoding.UTF8.GetBytes(strReader.Read());
+            }
+            else
+            {
+                throw new UnreachableException();
+            }
+            lengthBuilder.WriteValue(values.Length);
+            byteBuilder.WriteValues(values);
         }
 
-        return new SplitColumn(lengthBuilder.BuildDataColumn(), byteBuilder.BuildDataColumn(), dataColumn.LogicalType);
+        return new SplitColumn(lengthBuilder.BuildDataColumn(), byteBuilder.BuildDataColumn(), typeof(T).ToLogicalType());
     }
 
     public IColumnReader CreateDecoder(LogicalType type,

--- a/TapResult/Encodings/SplitEncoding.cs
+++ b/TapResult/Encodings/SplitEncoding.cs
@@ -38,7 +38,7 @@ public sealed class SplitEncoding : IEncoding
         return new SplitColumn(lengthBuilder.BuildDataColumn(), byteBuilder.BuildDataColumn(), typeof(T).ToLogicalType());
     }
 
-    public IColumnReader CreateDecoder(LogicalType type,
+    public IColumnReader CreateDecoder(LogicalType type, int length,
         GenericReader metadataReader, IEnumerable<IColumnReader> childColumns)
     {
         using IEnumerator<IColumnReader> childColumnEnumerator = childColumns.GetEnumerator();

--- a/TapResult/LogicalType.cs
+++ b/TapResult/LogicalType.cs
@@ -49,8 +49,8 @@ public static class TypeHelper
             LogicalType.Float16 => typeof(Half),
             LogicalType.Float32 => typeof(float),
             LogicalType.Float64 => typeof(double),
-            LogicalType.String => typeof(string),
             LogicalType.Blob => typeof(byte[]),
+            LogicalType.String => typeof(string),
             _ => throw new ArgumentOutOfRangeException(nameof(logicalType), logicalType, null)
         };
 
@@ -104,6 +104,44 @@ public static class TypeHelper
     /// </summary>
     public static LogicalType ToLogicalType(this Type type) => PhysicalTypes[type];
 
+    private static readonly Dictionary<LogicalType, HashSet<LogicalType>> CompatibilityGroups = GetCompatibilityLookup();
+
+    private static Dictionary<LogicalType, HashSet<LogicalType>> GetCompatibilityLookup()
+    {
+        Dictionary<LogicalType, HashSet<LogicalType>> compatibilityLookup = new Dictionary<LogicalType, HashSet<LogicalType>>();
+        foreach (HashSet<LogicalType> compatibilityGroup in CompatibilityGroups().Select(c => c.ToHashSet()))
+        {
+            foreach (LogicalType logicalType in compatibilityGroup)
+            {
+                compatibilityLookup.Add(logicalType, compatibilityGroup);
+            }
+        }
+
+        return compatibilityLookup;
+        
+        IEnumerable<IEnumerable<LogicalType>> CompatibilityGroups()
+        {
+            yield return VariableLengthTypes();
+            yield return [LogicalType.SInt8, LogicalType.UInt8];
+            yield return [LogicalType.SInt16, LogicalType.UInt16];
+            yield return [LogicalType.SInt32, LogicalType.UInt32];
+            yield return [LogicalType.SInt64, LogicalType.UInt64];
+        }
+    }
+    
+    /// <summary>
+    /// Checks whether two logical types are compatible with each other.
+    /// Compatibility means they have the same length and it makes sense to read one value as the other.
+    /// For example a string is the same as a blob, and a uint32 is the same as a sint32.
+    /// </summary>
+    /// <param name="type"></param>
+    /// <param name="type2"></param>
+    /// <returns></returns>
+    public static bool IsCompatible(this LogicalType type, LogicalType type2)
+    {
+        return CompatibilityGroups.TryGetValue(type, out HashSet<LogicalType>? group) && group.Contains(type2);
+    }
+    
     /// <summary>
     /// Gets all integer types as logical types.
     /// SInt8-SInt64 and UInt8-UInt64.

--- a/TapResult/Reader.cs
+++ b/TapResult/Reader.cs
@@ -63,6 +63,7 @@ public sealed class Reader
         ReadOnlySpan<int> parentIds = schemaReader.Read<int>(logicalLength);
         ReadOnlySpan<byte> encodingIds = schemaReader.Read<byte>(logicalLength);
         ReadOnlySpan<byte> types = schemaReader.Read<byte>(logicalLength);
+        ReadOnlySpan<int> lengths = schemaReader.Read<int>(logicalLength);
 
         Dictionary<int, EncodingInfo> encodingsById = new Dictionary<int, EncodingInfo>();
         for (int i = 0; i < logicalLength; i++)
@@ -70,7 +71,7 @@ public sealed class Reader
             int blobLength = schemaReader.Read<int>();
             ReadOnlyMemory<byte> blob = new ReadOnlyMemory<byte>(schema, schemaReader.ByteIndex, blobLength);
             schemaReader.Advance(blobLength);
-            encodingsById.Add(ids[i], new EncodingInfo(ids[i], parentIds[i], (EncodingType)encodingIds[i], (LogicalType)types[i], blob));
+            encodingsById.Add(ids[i], new EncodingInfo(ids[i], parentIds[i], (EncodingType)encodingIds[i], (LogicalType)types[i], lengths[i], blob));
         }
         
         List<EncodingInfo> tableEncodings = new List<EncodingInfo>();
@@ -116,16 +117,15 @@ public sealed class Reader
         if (encodingInfo.Encoding == EncodingType.Binary)
         {
             int physicalSize = reader.Read<int>();
-            int logicalLength = reader.Read<int>();
             long offset = reader.Read<long>();
             _stream.Seek(offset, SeekOrigin.Begin);
             byte[] data = new byte[physicalSize];
             _stream.ReadExactly(data);
-            DataColumn col = new DataColumn(encodingInfo.Type, data, logicalLength);
+            DataColumn col = new DataColumn(encodingInfo.Type, data, encodingInfo.Length);
             return col.OpenReader();
         }
         
         IEnumerable<IColumnReader> childReaders = encodingInfo.GetSubEncodings().Select(CreateReader);
-        return _encoder.Decode(encodingInfo.Encoding, encodingInfo.Type, ref reader, childReaders);
+        return _encoder.Decode(encodingInfo.Encoding, encodingInfo.Type, encodingInfo.Length, ref reader, childReaders);
     }
 }

--- a/TapResult/Readers/BitPackingColumnReader.cs
+++ b/TapResult/Readers/BitPackingColumnReader.cs
@@ -58,6 +58,19 @@ internal sealed class BitPackingColumnReader<T> : IColumnReader<T>
         return Peek(offset, count).OfType<object>();
     }
 
+    public IColumnReader<T> Clone()
+    {
+        return new BitPackingColumnReader<T>(ColumnReader.Clone(), Length, Type, PrefixLength, Prefix)
+        {
+            Index = Index,
+        };
+    }
+
+    IColumnReader IColumnReader.Clone()
+    {
+        return Clone();
+    }
+
     object IColumnReader.Peek(int offset)
     {
         return Peek(offset);

--- a/TapResult/Readers/IColumnReader.cs
+++ b/TapResult/Readers/IColumnReader.cs
@@ -1,4 +1,6 @@
-﻿namespace TapResult.Readers;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace TapResult.Readers;
 
 /// <summary>
 /// The base of a column reader. Most likely you want to cast this to a <see cref="IColumnReader{T}"/> of the correct type.
@@ -17,6 +19,10 @@ public interface IColumnReader
     /// The current index of the column reader.
     /// </summary>
     public int Index { get; }
+    /// <summary>
+    /// The <see cref="LogicalType"/> of this reader.
+    /// </summary>
+    public LogicalType Type { get; }
     /// <summary>
     /// Advance the column reader an amount of units in its source.
     /// </summary>
@@ -102,5 +108,22 @@ public static class ColumnReaderExtensions {
         {
             yield return reader.Read();
         }
+    }
+    
+    /// <summary>
+    /// Tries to convert an <see cref="IColumnReader{T}"/> into another compatible <see cref="IColumnReader{T}"/>.
+    /// Compatibility is defined by <see cref="TypeHelper.IsCompatible"/>.
+    /// </summary>
+    public static bool TryConvertReader<T>(this IColumnReader inReader, [NotNullWhen(true)] out IColumnReader<T>? outReader)
+    {
+        Type outType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+        if (inReader.Type.IsCompatible(outType.ToLogicalType()) || inReader is not IColumnReader<T> reader)
+        {
+            outReader = null;
+            return false;
+        }
+
+        outReader = reader;
+        return true;
     }
 }

--- a/TapResult/Readers/IColumnReader.cs
+++ b/TapResult/Readers/IColumnReader.cs
@@ -31,6 +31,11 @@ public interface IColumnReader
     /// Peeks multiple values with some offset. Does not consume.
     /// </summary>
     public IEnumerable<object?> Peek(int offset, int count);
+
+    /// <summary>
+    /// Clone this column reader at the current index.
+    /// </summary>
+    public IColumnReader Clone();
 }
 
 /// <summary>
@@ -46,6 +51,11 @@ public interface IColumnReader<out T> : IColumnReader
     /// Peeks multiple values with some offset. Does not consume.
     /// </summary>
     public new IEnumerable<T> Peek(int offset, int count);
+
+    /// <summary>
+    /// Clone this column reader at the current index.
+    /// </summary>
+    public new IColumnReader<T> Clone();
 }
 
 /// <summary>

--- a/TapResult/Readers/NullReader.cs
+++ b/TapResult/Readers/NullReader.cs
@@ -5,17 +5,19 @@ internal abstract class NullReaderBase : IColumnReader
     protected IColumnReader<byte> NullReader { get; }
     protected IColumnReader ValueReader { get; }
 
-    protected NullReaderBase(IColumnReader<byte> nullReader, IColumnReader valueReader, int length)
+    protected NullReaderBase(IColumnReader<byte> nullReader, IColumnReader valueReader, int length, LogicalType type)
     {
         NullReader = nullReader;
         ValueReader = valueReader;
         Length = length;
+        Type = type;
     }
 
     public int Length { get; }
     public int Index { get; protected set; } = 0;
+    public LogicalType Type { get; }
 
-    
+
     private int IsNull(int offset)
     {
         int index = Index + offset;
@@ -90,7 +92,8 @@ internal abstract class NullReaderBase : IColumnReader
 internal sealed class NullReaderValType<T> : NullReaderBase, IColumnReader<T?>
     where T : struct
 {
-    public NullReaderValType(IColumnReader<byte> nullReader, IColumnReader valueReader, int length) : base(nullReader, valueReader, length)
+    public NullReaderValType(IColumnReader<byte> nullReader, IColumnReader valueReader, int length, LogicalType type)
+        : base(nullReader, valueReader, length, type)
     {
     }
 
@@ -107,7 +110,7 @@ internal sealed class NullReaderValType<T> : NullReaderBase, IColumnReader<T?>
 
     IColumnReader<T?> IColumnReader<T?>.Clone()
     {
-        return new NullReaderValType<T>(NullReader.Clone(), ValueReader.Clone(), Length)
+        return new NullReaderValType<T>(NullReader.Clone(), ValueReader.Clone(), Length, Type)
         {
             Index = Index,
         };
@@ -122,7 +125,8 @@ internal sealed class NullReaderValType<T> : NullReaderBase, IColumnReader<T?>
 internal sealed class NullReaderRefType<T> : NullReaderBase, IColumnReader<T?>
     where T : class
 {
-    public NullReaderRefType(IColumnReader<byte> nullReader, IColumnReader valueReader, int length) : base(nullReader, valueReader, length)
+    public NullReaderRefType(IColumnReader<byte> nullReader, IColumnReader valueReader, int length, LogicalType type)
+        : base(nullReader, valueReader, length, type)
     {
     }
 
@@ -138,7 +142,7 @@ internal sealed class NullReaderRefType<T> : NullReaderBase, IColumnReader<T?>
 
     IColumnReader<T?> IColumnReader<T?>.Clone()
     {
-        return new NullReaderRefType<T>(NullReader.Clone(), ValueReader.Clone(), Length)
+        return new NullReaderRefType<T>(NullReader.Clone(), ValueReader.Clone(), Length, Type)
         {
             Index = Index,
         };

--- a/TapResult/Readers/NullReader.cs
+++ b/TapResult/Readers/NullReader.cs
@@ -2,18 +2,18 @@
 
 internal abstract class NullReaderBase : IColumnReader
 {
-    private readonly IColumnReader<byte> _nullReader;
-    private readonly IColumnReader _valueReader;
+    protected IColumnReader<byte> NullReader { get; }
+    protected IColumnReader ValueReader { get; }
 
     protected NullReaderBase(IColumnReader<byte> nullReader, IColumnReader valueReader, int length)
     {
-        _nullReader = nullReader;
-        _valueReader = valueReader;
+        NullReader = nullReader;
+        ValueReader = valueReader;
         Length = length;
     }
 
     public int Length { get; }
-    public int Index { get; private set; } = 0;
+    public int Index { get; protected set; } = 0;
 
     
     private int IsNull(int offset)
@@ -21,7 +21,7 @@ internal abstract class NullReaderBase : IColumnReader
         int index = Index + offset;
         int byteIndex = index / 8;
         int bitIndex = index % 8;
-        byte currentNulls = _nullReader.Peek(_nullReader.Index - byteIndex);
+        byte currentNulls = NullReader.Peek(NullReader.Index - byteIndex);
 
         // We want to advance if the value is 0, so we use xor to flip the bit after shifting.
         return (currentNulls >> bitIndex) & 1;
@@ -36,13 +36,13 @@ internal abstract class NullReaderBase : IColumnReader
             Index += 1;
             if (Index % 8 == 0)
             {
-                _nullReader.Advance(1);
+                NullReader.Advance(1);
             }
         }
 
         if (advancedUnits > 0)
         {
-            _valueReader.Advance(advancedUnits);
+            ValueReader.Advance(advancedUnits);
         }
     }
 
@@ -59,7 +59,7 @@ internal abstract class NullReaderBase : IColumnReader
             valueOffset += IsNull(i) ^ 1;
         }
 
-        return _valueReader.Peek(valueOffset);
+        return ValueReader.Peek(valueOffset);
     }
 
     public IEnumerable<object?> Peek(int offset, int count)
@@ -79,10 +79,12 @@ internal abstract class NullReaderBase : IColumnReader
             else
             {
                 valueOffset += 1;
-                yield return _valueReader.Peek(valueOffset);
+                yield return ValueReader.Peek(valueOffset);
             }
         }
     }
+
+    public abstract IColumnReader Clone();
 }
 
 internal sealed class NullReaderValType<T> : NullReaderBase, IColumnReader<T?>
@@ -102,6 +104,19 @@ internal sealed class NullReaderValType<T> : NullReaderBase, IColumnReader<T?>
     {
         return base.Peek(offset, count).Cast<T?>();
     }
+
+    IColumnReader<T?> IColumnReader<T?>.Clone()
+    {
+        return new NullReaderValType<T>(NullReader.Clone(), ValueReader.Clone(), Length)
+        {
+            Index = Index,
+        };
+    }
+
+    public override IColumnReader Clone()
+    {
+        return ((IColumnReader<T?>)this).Clone();
+    }
 }
 
 internal sealed class NullReaderRefType<T> : NullReaderBase, IColumnReader<T?>
@@ -119,5 +134,18 @@ internal sealed class NullReaderRefType<T> : NullReaderBase, IColumnReader<T?>
     public new IEnumerable<T?> Peek(int offset, int count)
     {
         return base.Peek(offset, count).Cast<T?>();
+    }
+
+    IColumnReader<T?> IColumnReader<T?>.Clone()
+    {
+        return new NullReaderRefType<T>(NullReader.Clone(), ValueReader.Clone(), Length)
+        {
+            Index = Index,
+        };
+    }
+
+    public override IColumnReader Clone()
+    {
+        return ((IColumnReader<T?>)this).Clone();
     }
 }

--- a/TapResult/Readers/PrimitiveReader.cs
+++ b/TapResult/Readers/PrimitiveReader.cs
@@ -9,11 +9,13 @@ internal sealed class PrimitiveReader<T> : IColumnReader<T>
     private ReadOnlyMemory<byte> _data;
     public int Length { get; }
     public int Index { get; private set; } = 0;
+    public LogicalType Type { get; }
 
-    internal PrimitiveReader(ReadOnlyMemory<byte> data)
+    internal PrimitiveReader(ReadOnlyMemory<byte> data, LogicalType type)
     {
         Length = data.Length / Unsafe.SizeOf<T>();
         _data = data;
+        Type = type;
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
@@ -40,7 +42,7 @@ internal sealed class PrimitiveReader<T> : IColumnReader<T>
 
     public IColumnReader<T> Clone()
     {
-        return new PrimitiveReader<T>(_data)
+        return new PrimitiveReader<T>(_data, Type)
         {
             Index = Index,
         };

--- a/TapResult/Readers/PrimitiveReader.cs
+++ b/TapResult/Readers/PrimitiveReader.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace TapResult.Readers;
 
-internal struct PrimitiveReader<T> : IColumnReader<T>
+internal sealed class PrimitiveReader<T> : IColumnReader<T>
     where T : unmanaged
 {
     private ReadOnlyMemory<byte> _data;
@@ -36,6 +36,19 @@ internal struct PrimitiveReader<T> : IColumnReader<T>
     IEnumerable<object> IColumnReader.Peek(int offset, int count)
     {
         return Peek(offset, count).OfType<object>();
+    }
+
+    public IColumnReader<T> Clone()
+    {
+        return new PrimitiveReader<T>(_data)
+        {
+            Index = Index,
+        };
+    }
+
+    IColumnReader IColumnReader.Clone()
+    {
+        return Clone();
     }
 
     object IColumnReader.Peek(int offset)

--- a/TapResult/Readers/RunLengthReader.cs
+++ b/TapResult/Readers/RunLengthReader.cs
@@ -7,17 +7,19 @@ public class RunLengthReader<T> : IColumnReader<T>
     private readonly IColumnReader<T> _byteColumn;
     private readonly IColumnReader<int> _repeatColumn;
 
-    public RunLengthReader(IColumnReader byteColumn, IColumnReader<int> repeatColumn, int length)
+    public RunLengthReader(IColumnReader byteColumn, IColumnReader<int> repeatColumn, int length, LogicalType type)
     {
         if (byteColumn is not IColumnReader<T> columnReader)
             throw new ArgumentException($"{nameof(columnReader)} not a {nameof(IColumnReader<T>)}");
         _byteColumn = columnReader;
         _repeatColumn = repeatColumn;
         Length = length;
+        Type = type;
     }
 
     public int Length { get; }
     public int Index { get; private set; }
+    public LogicalType Type { get; }
     private int _repeatIndex = 0;
 
     public void Advance(int units)
@@ -44,7 +46,7 @@ public class RunLengthReader<T> : IColumnReader<T>
 
     public IColumnReader<T> Clone()
     {
-        return new RunLengthReader<T>(_byteColumn.Clone(), _repeatColumn.Clone(), Length)
+        return new RunLengthReader<T>(_byteColumn.Clone(), _repeatColumn.Clone(), Length, Type)
         {
             Index = Index,
             _repeatIndex = _repeatIndex,

--- a/TapResult/Readers/RunLengthReader.cs
+++ b/TapResult/Readers/RunLengthReader.cs
@@ -42,6 +42,20 @@ public class RunLengthReader<T> : IColumnReader<T>
         return Peek(offset, count).OfType<object?>();
     }
 
+    public IColumnReader<T> Clone()
+    {
+        return new RunLengthReader<T>(_byteColumn.Clone(), _repeatColumn.Clone(), Length)
+        {
+            Index = Index,
+            _repeatIndex = _repeatIndex,
+        };
+    }
+
+    IColumnReader IColumnReader.Clone()
+    {
+        return Clone();
+    }
+
     public T Peek(int offset = 0)
     {
         int indexOffset = 0;

--- a/TapResult/Readers/SplitColumnReader.cs
+++ b/TapResult/Readers/SplitColumnReader.cs
@@ -7,16 +7,16 @@ internal sealed class SplitColumnReader : IColumnReader<string>, IColumnReader<b
 {
     private readonly IColumnReader<int> _lengthColumn;
     private readonly IColumnReader<byte> _byteColumn;
-    private readonly LogicalType _type;
 
     public int Length => _lengthColumn.Length;
     public int Index => _lengthColumn.Index;
+    public LogicalType Type { get; }
 
     public SplitColumnReader(IColumnReader<int> lengthColumn, IColumnReader<byte> byteColumn, LogicalType type)
     {
         _lengthColumn = lengthColumn;
         _byteColumn = byteColumn;
-        _type = type;
+        Type = type;
     }
 
     public void Advance(int units)
@@ -30,11 +30,11 @@ internal sealed class SplitColumnReader : IColumnReader<string>, IColumnReader<b
 
     IEnumerable<object> IColumnReader.Peek(int offset, int count)
     {
-        if (_type == LogicalType.Blob)
+        if (Type == LogicalType.Blob)
         {
             return ((IColumnReader<byte[]>)this).Peek(offset, count);
         }
-        if (_type == LogicalType.String)
+        if (Type == LogicalType.String)
         {
             return ((IColumnReader<string>)this).Peek(offset, count);
         }
@@ -44,7 +44,7 @@ internal sealed class SplitColumnReader : IColumnReader<string>, IColumnReader<b
 
     private SplitColumnReader Clone()
     {
-        return new SplitColumnReader(_lengthColumn.Clone(), _byteColumn.Clone(), _type);
+        return new SplitColumnReader(_lengthColumn.Clone(), _byteColumn.Clone(), Type);
     }
 
     IColumnReader<byte[]> IColumnReader<byte[]>.Clone()
@@ -64,11 +64,11 @@ internal sealed class SplitColumnReader : IColumnReader<string>, IColumnReader<b
 
     object IColumnReader.Peek(int offset)
     {
-        if (_type == LogicalType.Blob)
+        if (Type == LogicalType.Blob)
         {
             return ((IColumnReader<byte[]>)this).Peek(offset);
         }
-        if (_type == LogicalType.String)
+        if (Type == LogicalType.String)
         {
             return ((IColumnReader<string>)this).Peek(offset);
         }

--- a/TapResult/Readers/SplitColumnReader.cs
+++ b/TapResult/Readers/SplitColumnReader.cs
@@ -42,6 +42,26 @@ internal sealed class SplitColumnReader : IColumnReader<string>, IColumnReader<b
         throw new UnreachableException();
     }
 
+    private SplitColumnReader Clone()
+    {
+        return new SplitColumnReader(_lengthColumn.Clone(), _byteColumn.Clone(), _type);
+    }
+
+    IColumnReader<byte[]> IColumnReader<byte[]>.Clone()
+    {
+        return Clone();
+    }
+
+    IColumnReader<string> IColumnReader<string>.Clone()
+    {
+        return Clone();
+    }
+
+    IColumnReader IColumnReader.Clone()
+    {
+        return Clone();
+    }
+
     object IColumnReader.Peek(int offset)
     {
         if (_type == LogicalType.Blob)

--- a/TapResult/Readers/VarLengthReader.cs
+++ b/TapResult/Readers/VarLengthReader.cs
@@ -8,15 +8,15 @@ namespace TapResult.Readers;
 internal sealed class VarLengthReader : IColumnReader<string>, IColumnReader<byte[]>
 {
     private readonly ReadOnlyMemory<byte> _data;
-    private readonly LogicalType _type;
     private int _byteIndex;
     public int Length { get; }
     public int Index { get; private set; }
+    public LogicalType Type { get; }
 
     internal VarLengthReader(ReadOnlyMemory<byte> data, int length, LogicalType type)
     {
         _data = data;
-        _type = type;
+        Type = type;
         Length = length;
     }
 
@@ -52,11 +52,11 @@ internal sealed class VarLengthReader : IColumnReader<string>, IColumnReader<byt
 
     IEnumerable<object> IColumnReader.Peek(int offset, int count)
     {
-        if (_type == LogicalType.Blob)
+        if (Type == LogicalType.Blob)
         {
             return ((IColumnReader<byte[]>)this).Peek(offset, count);
         }
-        if (_type == LogicalType.String)
+        if (Type == LogicalType.String)
         {
             return ((IColumnReader<string>)this).Peek(offset, count);
         }
@@ -66,11 +66,11 @@ internal sealed class VarLengthReader : IColumnReader<string>, IColumnReader<byt
 
     object IColumnReader.Peek(int offset)
     {
-        if (_type == LogicalType.Blob)
+        if (Type == LogicalType.Blob)
         {
             return ((IColumnReader<byte[]>)this).Peek(offset);
         }
-        if (_type == LogicalType.String)
+        if (Type == LogicalType.String)
         {
             return ((IColumnReader<string>)this).Peek(offset);
         }
@@ -108,7 +108,7 @@ internal sealed class VarLengthReader : IColumnReader<string>, IColumnReader<byt
 
     private VarLengthReader Clone()
     {
-        return new VarLengthReader(_data, Length, _type)
+        return new VarLengthReader(_data, Length, Type)
         {
             Index = Index,
         };

--- a/TapResult/Readers/VarLengthReader.cs
+++ b/TapResult/Readers/VarLengthReader.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace TapResult.Readers;
 
-internal struct VarLengthReader : IColumnReader<string>, IColumnReader<byte[]>
+internal sealed class VarLengthReader : IColumnReader<string>, IColumnReader<byte[]>
 {
     private readonly ReadOnlyMemory<byte> _data;
     private readonly LogicalType _type;
@@ -104,5 +104,28 @@ internal struct VarLengthReader : IColumnReader<string>, IColumnReader<byte[]>
         {
             yield return blobReader.Peek(offset + i);
         }
+    }
+
+    private VarLengthReader Clone()
+    {
+        return new VarLengthReader(_data, Length, _type)
+        {
+            Index = Index,
+        };
+    }
+
+    IColumnReader<byte[]> IColumnReader<byte[]>.Clone()
+    {
+        return Clone();
+    }
+
+    IColumnReader<string> IColumnReader<string>.Clone()
+    {
+        return Clone();
+    }
+
+    IColumnReader IColumnReader.Clone()
+    {
+        return Clone();
     }
 }

--- a/TapResult/Table.cs
+++ b/TapResult/Table.cs
@@ -17,6 +17,7 @@ public sealed class Table : IColumnParent
 
     public EncodingType EncodingType => EncodingType.Table;
     public LogicalType LogicalType => LogicalType.UInt8;
+    public int LogicalLength { get; }
 
     public IEnumerable<IColumn> GetChildColumns()
     {
@@ -85,6 +86,9 @@ public sealed class Table : IColumnParent
         _columns = columns.ToArray();
         _names = names.ToArray();
         Name = name;
+        Debug.Assert(_columns.Any());
         Debug.Assert(_columns.Count() == _names.Count());
+        LogicalLength = _columns.First().LogicalLength;
+        Debug.Assert(_columns.All(c => c.LogicalLength == LogicalLength));
     }
 }

--- a/TapResult/Writer.cs
+++ b/TapResult/Writer.cs
@@ -123,8 +123,8 @@ public sealed class Writer : IDisposable, IAsyncDisposable
         _parentIdBuilder.WriteValue(parentId);
         _encodingIdBuilder.WriteValue((byte) column.EncodingType);
         _logicalTypeBuilder.WriteValue((byte) column.LogicalType);
-        column.WriteMetadata(_blobBuilder.OpenBlob());
-        _blobBuilder.CloseBlob();
+        using BlobBuilder blobBuilder = _blobBuilder.OpenBlob();
+        column.WriteMetadata(blobBuilder);
     }
     
     internal Table GetMetadata()

--- a/TapResult/Writer.cs
+++ b/TapResult/Writer.cs
@@ -15,7 +15,8 @@ public sealed class Writer : IDisposable, IAsyncDisposable
     private ColumnBuilder _idBuilder = new (LogicalType.SInt32, 200);
     private ColumnBuilder _parentIdBuilder = new (LogicalType.SInt32, 200);
     private ColumnBuilder _encodingIdBuilder = new (LogicalType.UInt8, 200);
-    private ColumnBuilder _logicalTypeBuilder = new(LogicalType.UInt8, 200);
+    private ColumnBuilder _logicalTypeBuilder = new (LogicalType.UInt8, 200);
+    private ColumnBuilder _lengthBuilder = new (LogicalType.SInt32, 200);
     private ColumnBuilder _blobBuilder = new (LogicalType.Blob, 200);
     
     private const byte MajorVersion = 1;
@@ -59,7 +60,8 @@ public sealed class Writer : IDisposable, IAsyncDisposable
         _parentIdBuilder.BuildDataColumn().Write(_outStream);
         _encodingIdBuilder.BuildDataColumn().Write(_outStream);
         _logicalTypeBuilder.BuildDataColumn().Write(_outStream);
-        _blobBuilder.BuildDataColumn() .Write(_outStream);
+        _lengthBuilder.BuildDataColumn().Write(_outStream);
+        _blobBuilder.BuildDataColumn().Write(_outStream);
         
         // Postscript
         long metadataLength = _outStream.Position - metadataStart;
@@ -123,14 +125,15 @@ public sealed class Writer : IDisposable, IAsyncDisposable
         _parentIdBuilder.WriteValue(parentId);
         _encodingIdBuilder.WriteValue((byte) column.EncodingType);
         _logicalTypeBuilder.WriteValue((byte) column.LogicalType);
+        _lengthBuilder.WriteValue(column.LogicalLength);
         using BlobBuilder blobBuilder = _blobBuilder.OpenBlob();
         column.WriteMetadata(blobBuilder);
     }
     
     internal Table GetMetadata()
     {
-        return new Table([_idBuilder.BuildDataColumn(), _parentIdBuilder.BuildDataColumn(), _encodingIdBuilder.BuildDataColumn(), _logicalTypeBuilder.BuildDataColumn(), _blobBuilder.BuildDataColumn()],
-            ["Id", "ParentId", "Encoding", "LogicalType", "Blob"],
+        return new Table([_idBuilder.BuildDataColumn(), _parentIdBuilder.BuildDataColumn(), _encodingIdBuilder.BuildDataColumn(), _logicalTypeBuilder.BuildDataColumn(), _lengthBuilder.BuildDataColumn(), _blobBuilder.BuildDataColumn()],
+            ["Id", "ParentId", "Encoding", "LogicalType", "Length", "Blob"],
             "schema");
     }
 }


### PR DESCRIPTION
Removes some places where the datacolumn was previously used.
This is as a preparation for the columnbuilder to start producing split columns directly.

Merge #84 first